### PR TITLE
ner: fix make_gold recipe

### DIFF
--- a/ner/ner_make_gold.py
+++ b/ner/ner_make_gold.py
@@ -43,7 +43,7 @@ def make_tasks(nlp, stream, labels):
     dataset=("The dataset to use", "positional", None, str),
     spacy_model=("The base model", "positional", None, str),
     source=("The source data as a JSONL file", "positional", None, str),
-    label=("One or more comma-separated labels", "options", "l", split_string),
+    label=("One or more comma-separated labels", "option", "l", split_string),
     exclude=("Names of datasets to exclude", "option", "e", split_string)
 )
 def ner_make_gold(dataset, spacy_model, source, label=None, exclude=None):


### PR DESCRIPTION
Hi,

this PR fixes the `make_gold` recipe for NER. The current version of the recipe does not work (tested with Prodigy 1.8) due to this error message:

```bash

Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/prodigy/__main__.py", line 380, in <module>
    controller = recipe(*args, use_plac=True)
  File "cython_src/prodigy/core.pyx", line 212, in prodigy.core.recipe.recipe_decorator.recipe_proxy
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/plac_core.py", line 324, in call
    parser = parser_from(obj)
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/plac_core.py", line 133, in parser_from
    parser.populate_from(obj)
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/plac_core.py", line 257, in populate_from
    a = Annotation.from_(ann)
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/plac_core.py", line 91, in from_
    return cls(*obj)
  File "/media/stefan/00eb2e8f-6826-4043-a1d7-937b9d5341c1/.venvs/prodigy/lib/python3.7/site-packages/plac_core.py", line 76, in __init__
    assert kind in ('positional', 'option', 'flag'), kind
AssertionError: options
```

This PR corrects the `option` attribute.