### PR TITLE
Fuzzy ner

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can edit the code in the recipe script to customize how Prodigy behaves.
 | [`mark`](other/mark.py)                             | Click through pre-prepared examples, with no model in the loop.                                                                                                    |
 | [`choice`](other/choice.py)                         | Annotate data with multiple-choice options. The annotated examples will have an additional property `"accept": []` mapping to the ID(s) of the selected option(s). |
 | [`question_answering`](other/question_answering.py) | Annotate question/answer pairs with a custom HTML interface.                                                                                                       |
+| [`ner_fuzzy_manual`](other/ner_fuzzy_manual.py) | Mark spans manually by token with suggestions from [`spaczz fuzzy`](https://spacy.io/universe/project/spaczz) matcher patterns pre-highlighted.
 
 ### Community recipes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can edit the code in the recipe script to customize how Prodigy behaves.
 | [`mark`](other/mark.py)                             | Click through pre-prepared examples, with no model in the loop.                                                                                                    |
 | [`choice`](other/choice.py)                         | Annotate data with multiple-choice options. The annotated examples will have an additional property `"accept": []` mapping to the ID(s) of the selected option(s). |
 | [`question_answering`](other/question_answering.py) | Annotate question/answer pairs with a custom HTML interface.                                                                                                       |
-| [`ner_fuzzy_manual`](other/ner_fuzzy_manual.py) | Mark spans manually by token with suggestions from [`spaczz fuzzy`](https://spacy.io/universe/project/spaczz) matcher patterns pre-highlighted.
+| [`ner_fuzzy_manual`](other/ner_fuzzy_manual.py) | Mark spans manually by token with suggestions from [`spaczz fuzzy`](https://spacy.io/universe/project/spaczz) matcher pre-highlighted.
 
 ### Community recipes
 

--- a/example-patterns/patterns_skateboarding_tricks-TRICK.jsonl
+++ b/example-patterns/patterns_skateboarding_tricks-TRICK.jsonl
@@ -1,0 +1,15 @@
+{"label":"TRICK","pattern":"forward flip"}
+{"label":"TRICK","pattern":"drop-in"}
+{"label":"TRICK","pattern":"manual"}
+{"label":"TRICK","pattern":"ride switch"}
+{"label":"TRICK","pattern":"manny"}
+{"label":"TRICK","pattern":"kick turn"}
+{"label":"TRICK","pattern":"kickflip"}
+{"label":"TRICK","pattern":"treflip"}
+{"label":"TRICK","pattern":"tic-tac"}
+{"label":"TRICK","pattern":"ollie"}
+{"label":"TRICK","pattern":"180 ollie"}
+{"label":"TRICK","pattern":"boardslide"}
+{"label":"TRICK","pattern":"rock to fakie"}
+{"label":"TRICK","pattern":"shove-it"}
+{"label":"TRICK","pattern":"anti casper flip"}

--- a/other/ner_fuzzy_manual.py
+++ b/other/ner_fuzzy_manual.py
@@ -15,7 +15,7 @@ def parse_phrase_patterns(patterns):
     phrase_patterns = defaultdict(list)
     # Auxiliary map to recover the pattern id as line number in the UI
     line_numbers = {}
-     for i, entry in enumerate(patterns):
+    for i, entry in enumerate(patterns):
         label = entry["label"]
         pattern = entry["pattern"]
         line_number = i+1
@@ -33,13 +33,13 @@ def apply_fuzzy_matcher(stream, nlp, fuzzy_matcher, line_numbers):
         task = copy.deepcopy(eg)
         matched_spans = []
         for line_number, start_token, end_token, _ in fuzzy_matcher(doc):
-            #span_obj = Span(doc, start_token, end_token)
+            span_obj = Span(doc, start_token, end_token)
             span = {
-                        "text": doc[start_token, end_token],
-                        "token_start": start_token,
-                        "token_end": end_token - 1,
-                        "start": start_token[0],
-                        "end": end_token[-1],
+                        "text": span_obj.text,
+                        "start": span_obj.start_char,
+                        "end": span_obj.end_char,
+                        "token_start": span_obj.start,
+                        "token_end": span_obj.end -1,
                         "label": line_numbers[line_number],
                         "line_number": line_number
                     }
@@ -52,6 +52,7 @@ def apply_fuzzy_matcher(stream, nlp, fuzzy_matcher, line_numbers):
                 # Not needed anymore
                 del s["line_number"]
             task["meta"]["pattern"] = ", ".join([f"{p}" for p in all_ids])
+            # Rehash the newly created task so that hashes reflect added data
             task = set_hashes(task)
         yield task
 
@@ -95,7 +96,7 @@ def ner_fuzzy_manual(
 
     # Load phrase patterns and feed them to spaczz matcher
     patterns = JSONL(patterns)
-    phrase_patterns, line_numbers = parse_patterns(list(patterns))
+    phrase_patterns, line_numbers = parse_phrase_patterns(list(patterns))
     for pattern_label, patterns in phrase_patterns.items():
         for (line_number, pattern) in patterns:
             # Use the line number from the patterns source file as the pattern_id

--- a/other/ner_fuzzy_manual.py
+++ b/other/ner_fuzzy_manual.py
@@ -11,7 +11,10 @@ from spaczz.matcher import FuzzyMatcher
 
 
 def parse_phrase_patterns(patterns):
-    """ A parser for patterns file. It assumes spaCy phrase patterns format"""
+    """
+        A parser for patterns file.
+        It assumes Prodigy's patterns format with string patterns such as {"pattern": "some pattern", "label": "SOME_LABEL"}.
+    """
     phrase_patterns = defaultdict(list)
     # Auxiliary map to recover the pattern id as line number in the UI
     line_numbers = {}

--- a/other/ner_fuzzy_manual.py
+++ b/other/ner_fuzzy_manual.py
@@ -1,0 +1,111 @@
+from typing import List, Optional
+import copy
+from collections import defaultdict
+import prodigy
+from prodigy.components.loaders import JSONL
+from prodigy.components.preprocess import add_tokens
+from prodigy.util import split_string, set_hashes
+from prodigy.models.matcher import parse_patterns
+import spacy
+from spacy.tokens import Span
+from spaczz.matcher import FuzzyMatcher
+
+
+def apply_fuzzy_matcher(stream, nlp, fuzzy_matcher, pattern_labels, line_numbers):
+    """Add a 'spans' key to each example, with fuzzy pattern matches."""
+    # Process the stream using spaCy's nlp.pipe, which yields doc objects.
+    # If as_tuples=True is set, you can pass in (text, context) tuples.
+    texts_examples = ((eg["text"], eg) for eg in stream)
+    for doc, eg in nlp.pipe(texts_examples, as_tuples=True):
+        task = copy.deepcopy(eg)
+        matched_spans = []
+        for match_id, start_token, end_token, _ in fuzzy_matcher(doc):
+            span_obj = Span(doc, start_token, end_token)
+            span = {
+                        "text": span_obj.text,
+                        "start": span_obj.start_char,
+                        "end": span_obj.end_char,
+                        "pattern": span_obj.label,
+                        "token_start": span_obj.start,
+                        "token_end": span_obj.end - 1,
+                        "label": pattern_labels[match_id],
+                        "pattern_hash": match_id
+                    }
+            matched_spans.append(span)
+        if matched_spans:
+            task["spans"] = matched_spans
+            all_ids = [line_numbers[s["pattern_hash"]]+1 for s in task["spans"]]
+            task["meta"]["pattern"] = ", ".join([f"{p}" for p in all_ids])
+            task = set_hashes(task)
+        yield task
+
+
+# Recipe decorator with argument annotations: (description, argument type,
+# shortcut, type / converter function called on value before it's passed to
+# the function). Descriptions are also shown when typing --help.
+@prodigy.recipe(
+    "ner.fuzzy.manual",
+    dataset=("The dataset to use", "positional", None, str),
+    spacy_model=("The base model", "positional", None, str),
+    source=("The source data as a JSONL file", "positional", None, str),
+    patterns=("Phrase patterns", "positional", None, str),
+    label=("One or more comma-separated labels", "option", "l", split_string),
+    exclude=("Names of datasets to exclude", "option", "e", split_string),
+    
+)
+def ner_fuzzy_manual(
+    dataset: str,
+    spacy_model: str,
+    source: str,
+    patterns: str,
+    label: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
+    
+):
+    """
+    Mark spans manually by token with suggestions from patterns pre-highlighted.
+    The suggestions are entity spans matched by spaczz fuzzy matcher ignoring the case.
+    Note, that if token patterns are required spaczz syntax for token patterns should be observed
+    and custom parsing function should be implemented. Please check spaczz documentation
+    for details: https://spacy.io/universe/project/spaczz.
+    The recipe doesn't require any entity recognizer, and it doesn't do any active learning.
+    It will present all examples in order, so even examples without matches are shown.
+    """
+    # Load the spaCy model for tokenization
+    nlp = spacy.load(spacy_model)
+
+    # Initialize spaczz fuzzy matcher
+    fuzzy_matcher = FuzzyMatcher(nlp.vocab)
+
+    # Load phrase patterns and feed them to spaczz matcher
+    patterns = JSONL(patterns)
+    _, phrase_patterns, line_numbers = parse_patterns(list(patterns))
+    pattern_labels = defaultdict(str)
+    for pattern_label, patterns in phrase_patterns.items():
+        for (pattern_hash, pattern) in patterns:
+            fuzzy_matcher.add(pattern_hash, [nlp(pattern)], kwargs= [{"ignorecase": True}])
+            # Build pattern hash to pattern map to recover the source pattern for UI
+            pattern_labels[pattern_hash] = pattern_label
+
+    # Load the stream from a JSONL file and return a generator that yields a
+    # dictionary for each example in the data.
+    stream = JSONL(source)
+
+    # Tokenize the incoming examples and add a "tokens" property to each
+    # example. Also handles pre-defined selected spans. Tokenization allows
+    # faster highlighting, because the selection can "snap" to token boundaries.
+    stream = add_tokens(nlp, stream)
+
+    # Apply the spaczz matcher to the stream.
+    stream = apply_fuzzy_matcher(stream, nlp, fuzzy_matcher, pattern_labels, line_numbers)
+
+    return {
+        "view_id": "ner_manual",  # Annotation interface to use
+        "dataset": dataset,  # Name of dataset to save annotations
+        "stream": stream,  # Incoming stream of examples
+        "exclude": exclude,  # List of dataset names to exclude
+        "config": {  # Additional config settings, mostly for app UI
+            "lang": nlp.lang,
+            "labels": label
+        },
+    }

--- a/other/ner_fuzzy_manual.py
+++ b/other/ner_fuzzy_manual.py
@@ -63,10 +63,10 @@ def ner_fuzzy_manual(
     
 ):
     """
-    Mark spans manually by token with suggestions from patterns pre-highlighted.
+    Mark spans manually by token with suggestions from spaCy phrase patterns pre-highlighted.
     The suggestions are entity spans matched by spaczz fuzzy matcher ignoring the case.
-    Note, that if token patterns are required spaczz syntax for token patterns should be observed
-    and custom parsing function should be implemented. Please check spaczz documentation
+    Note, that if spaCy token patterns are required, spaczz syntax for token patterns should be observed
+    and a custom parsing function should be implemented. Please check spaczz documentation
     for details: https://spacy.io/universe/project/spaczz.
     The recipe doesn't require any entity recognizer, and it doesn't do any active learning.
     It will present all examples in order, so even examples without matches are shown.
@@ -84,7 +84,7 @@ def ner_fuzzy_manual(
     for pattern_label, patterns in phrase_patterns.items():
         for (pattern_hash, pattern) in patterns:
             fuzzy_matcher.add(pattern_hash, [nlp(pattern)], kwargs= [{"ignorecase": True}])
-            # Build pattern hash to pattern map to recover the source pattern for UI
+            # Build pattern_hash to pattern map to recover the source pattern for UI.
             pattern_labels[pattern_hash] = pattern_label
 
     # Load the stream from a JSONL file and return a generator that yields a
@@ -96,7 +96,7 @@ def ner_fuzzy_manual(
     # faster highlighting, because the selection can "snap" to token boundaries.
     stream = add_tokens(nlp, stream)
 
-    # Apply the spaczz matcher to the stream.
+    # Apply the spaczz matcher to the stream and add matched spans to each task for pre-highlighting.
     stream = apply_fuzzy_matcher(stream, nlp, fuzzy_matcher, pattern_labels, line_numbers)
 
     return {


### PR DESCRIPTION
Added ner.fuzzy.manual recipe to `others`. It uses spaczz fuzzy matcher in place of spaCy matcher for pre-highlighting suggestions. Otherwise it works as ner.manual. I also added example patterns and data from skateboarding domain. I moved a few more interesting examples to the top of the file to enable quick trial. 